### PR TITLE
Fix apostrophe

### DIFF
--- a/src/HUD_HMIS.xsd
+++ b/src/HUD_HMIS.xsd
@@ -385,7 +385,7 @@
 					No Yes
 					0 = No
 					1 = Yes
-					8 = Client doesn't know
+					8 = Client doesn’t know
 					9 = Client refused
 					99 = Data not collected
 				</xs:documentation>
@@ -403,7 +403,7 @@
 				</xs:enumeration>			
 				<xs:enumeration value="8">
 					<xs:annotation>
-						<xs:documentation xml:lang="en">Client doesn't know</xs:documentation>
+						<xs:documentation xml:lang="en">Client doesn’t know</xs:documentation>
 					</xs:annotation>
 				</xs:enumeration>				
 				<xs:enumeration value="9">
@@ -2916,7 +2916,7 @@
 				Address Data Quality
 				1 = Full address reported
 				2 = Incomplete or estimated address reported
-				8 = Client doesn't know
+				8 = Client doesn’t know
 				9 = Client refused
 				99 = Data not collected
 			</xs:documentation>
@@ -2934,7 +2934,7 @@
 			</xs:enumeration>			
 			<xs:enumeration value="8">
 				<xs:annotation>
-					<xs:documentation xml:lang="en">Client doesn't know</xs:documentation>
+					<xs:documentation xml:lang="en">Client doesn’t know</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>				
 			<xs:enumeration value="9">
@@ -3007,7 +3007,7 @@
 			</xs:enumeration>			
 			<xs:enumeration value="8">
 				<xs:annotation>
-					<xs:documentation xml:lang="en">Client doesn't know</xs:documentation>
+					<xs:documentation xml:lang="en">Client doesn’t know</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>				
 			<xs:enumeration value="9">
@@ -4165,7 +4165,7 @@
 				No Yes
     				0 = No
     				1 = Yes
-    				8 = Client doesn't know
+    				8 = Client doesn’t know
     				9 = Client refused
     				99 = Data not collected
 			</xs:documentation>
@@ -4183,7 +4183,7 @@
 			</xs:enumeration>			
 			<xs:enumeration value="8">
 				<xs:annotation>
-					<xs:documentation xml:lang="en">Client doesn't know</xs:documentation>
+					<xs:documentation xml:lang="en">Client doesn’t know</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>				
 			<xs:enumeration value="9">
@@ -4284,7 +4284,7 @@
 			</xs:enumeration>	
 			<xs:enumeration value="8">
 				<xs:annotation>
-					<xs:documentation xml:lang="en">Client doesn't know</xs:documentation>
+					<xs:documentation xml:lang="en">Client doesn’t know</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>				
 			<xs:enumeration value="9">
@@ -4410,7 +4410,7 @@
 			</xs:enumeration>	
 			<xs:enumeration value="8">
 				<xs:annotation>
-					<xs:documentation xml:lang="en">Client doesn't know</xs:documentation>
+					<xs:documentation xml:lang="en">Client doesn’t know</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>				
 			<xs:enumeration value="9">
@@ -5037,7 +5037,7 @@
 	
 	<xs:simpleType name="noYesWorkerDoesntKnow">
 		<xs:annotation>
-			<xs:documentation xml:lang="en">0 = No, 1 = Yes, 2 = Worker Doesn't Know, 99 = Data Not Collected</xs:documentation>
+			<xs:documentation xml:lang="en">0 = No, 1 = Yes, 2 = Worker Doesn’t Know, 99 = Data Not Collected</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:unsignedInt">
 			<xs:enumeration value="0">
@@ -5052,7 +5052,7 @@
 			</xs:enumeration>
 			<xs:enumeration value="2">
 				<xs:annotation>
-					<xs:documentation xml:lang="en">Worker Doesn't Know</xs:documentation>
+					<xs:documentation xml:lang="en">Worker Doesn’t Know</xs:documentation>
 				</xs:annotation>
 			</xs:enumeration>
 			<xs:enumeration value="99">


### PR DESCRIPTION
Fix apostrophe character to be consistent, in all XSD XML text that says for example "doesn’t know". 

Before this commit, the XSD XML text mostly uses the right curly apostrophe, yet sometimes uses the single quote. The single quote causes glitches in automatic conversions to SQL.

In case it's helpful to consider, XML can use the right curly apostrophe encoding `&#8217;`. This encoding makes the text work well with XML, SQL, HTML, and also across various UTF encodings. I see that this repo contains a bunch of files that seem to be documentation that's automatically generated; if this is the case, then it's much better to use `&#8217;` because it will work correctly in both XML and HTML. For details https://dwheeler.com/essays/quotes-in-html.html
